### PR TITLE
Adapting extructures to upcoming mathcomp 1.13

### DIFF
--- a/extructures.opam
+++ b/extructures.opam
@@ -17,7 +17,7 @@ install: [
 depends: [
   "ocaml"
   "coq" {(>= "8.11" & < "8.14~") | (= "dev")}
-  "coq-mathcomp-ssreflect" {(>= "1.10" & < "1.13~") | (= "dev")}
+  "coq-mathcomp-ssreflect" {(>= "1.12" & < "1.14~") | (= "dev")}
   "coq-deriving" {(>= "0.1") | (= "dev")}
 ]
 tags: [

--- a/theories/fmap.v
+++ b/theories/fmap.v
@@ -633,7 +633,7 @@ Proof. exact: fmap_rect. Qed.
 
 Lemma val_domm m : domm m = unzip1 m :> seq _.
 Proof.
-apply: (eq_sorted (@Ord.lt_trans T)).
+apply: (sorted_eq (@Ord.lt_trans T)).
 - move=> x y /andP [/Ord.ltW xy /Ord.ltW yx].
   by apply: Ord.anti_leq; rewrite xy.
 - exact: valP.

--- a/theories/fset.v
+++ b/theories/fset.v
@@ -180,7 +180,7 @@ case: s1 s2 => [s1 Ps1] [s2 Ps2] /= E; apply/val_inj=> /=.
 have anti: antisymmetric (@Ord.lt T).
   move=> x y /andP [/Ord.ltW xy /Ord.ltW yx].
   exact: Ord.anti_leq (introT andP (conj xy yx)).
-rewrite -[s1 =i s2]/(_) in E; apply: (eq_sorted _ _ Ps1 Ps2) => //.
+rewrite -[s1 =i s2]/(_) in E; apply: (sorted_eq _ _ Ps1 Ps2) => //.
   exact: Ord.lt_trans.
 apply: uniq_perm => //; [move: Ps1|move: Ps2]; apply/sorted_uniq => //;
 by [apply: Ord.ltxx|apply: Ord.lt_trans].
@@ -782,7 +782,7 @@ Qed.
 Lemma val_fset_filter (P : T -> bool) (X : {fset T}) :
   fset_filter P X = filter P X :> seq T.
 Proof.
-apply: (eq_sorted (@Ord.lt_trans T)).
+apply: (sorted_eq (@Ord.lt_trans T)).
 - move=> x y /andP [/Ord.ltW xy /Ord.ltW yx].
   by apply: Ord.anti_leq; rewrite xy.
 - rewrite /fset_filter /fset unlock /=.


### PR DESCRIPTION
`eq_sorted` -> `sorted_eq`

@arthuraa this is actually the only change to perform to compile with the upcoming release of mathcomp